### PR TITLE
Lock in rspec, rspec-rails, cucumber-rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,8 @@ group :development do
 end
 
 group :test, :cucumber do
-  gem 'rspec-rails'
+  gem 'rspec', '1.3.1'
+  gem 'rspec-rails', '1.3.2'
   gem 'rr'
   gem 'machinist', :require => 'machinist/active_record'
   gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :test, :cucumber do
 #  gem 'autotest-growl'
   gem 'daemons'
   gem 'spork'
-  gem 'cucumber-rails'
+  gem 'cucumber-rails', '~>0.3.2'
   gem 'webrat'
   gem 'moro-miso'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,14 +118,7 @@ GEM
     redis-objects (0.5.0)
       redis (>= 2.1.1)
     rr (1.0.2)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
+    rspec (1.3.1)
     rspec-rails (1.3.2)
       rack (>= 1.0.0)
       rspec (>= 1.3.0)
@@ -205,7 +198,8 @@ DEPENDENCIES
   rails_warden
   redis-objects
   rr
-  rspec-rails
+  rspec (= 1.3.1)
+  rspec-rails (= 1.3.2)
   spork
   steak
   thin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ DEPENDENCIES
   capistrano-notification (= 0.0.2)
   capybara
   configatron
-  cucumber-rails
+  cucumber-rails (~> 0.3.2)
   daemons
   database_cleaner
   delayed_job


### PR DESCRIPTION
Gemfile に gem のバージョン指定がなかったため、rails2 系をサポートしていないバージョンに gem がインストールされてしまい rails2 系で動作しませんでした。
以下のように rails2 系をサポートしているバージョンに固定することで、 rails2系で動作するようにしました。
- rspec 1.3.1
- rspec-rails 1.3.2
- cucumber-rails 0.3.2
