### PR TITLE
fix 2011

### DIFF
--- a/app/views/registrations/_need_signin.ja.html.haml
+++ b/app/views/registrations/_need_signin.ja.html.haml
@@ -1,2 +1,2 @@
 %p
-  ! 日本Ruby会議2010のチケット購入・個人スポンサー申し込みでは、Twitter OAuthかOpenIDで#{link_to 'サインイン', signin_path}が要求されます。ご協力ください。
+  ! 日本Ruby会議2011のチケット購入・個人スポンサー申し込みでは、Twitter OAuthかOpenIDで#{link_to 'サインイン', signin_path}が要求されます。ご協力ください。


### PR DESCRIPTION
"Ruby会議2010" → "Ruby会議2011"
