### PR TITLE
スペルミスと思われるものを直しました。

### DIFF
--- a/db/2011/advent_events.yml
+++ b/db/2011/advent_events.yml
@@ -109,8 +109,8 @@ metacon2011:
   pub_date: '2011-06-08'
 
 trbmeetup:
-  hosted_by_en: 'Toyko Rubyist Meetup'
-  hosted_by_ja: 'Toyko Rubyist Meetup'
+  hosted_by_en: 'Tokyo Rubyist Meetup'
+  hosted_by_ja: 'Tokyo Rubyist Meetup'
   name_en: 'Ruby in the Park'
   name_ja: 'Ruby in the Park'
   dtstart: '2011-07-13 18:00'


### PR DESCRIPTION
advent_events.ymlにあるtrbmeetupのhost名称にスペルミスを発見しましたので修正しました。
-  hosted_by_en: 'Toyko Rubyist Meetup'
-  hosted_by_ja: 'Toyko Rubyist Meetup'
-  hosted_by_en: 'Tokyo Rubyist Meetup'
-  hosted_by_ja: 'Tokyo Rubyist Meetup'

確認よろしくお願い致します。
