### PR TITLE
RubyKaigi Advent Calendar 2011への参加申し込み

### DIFF
--- a/db/2011/advent_events.yml
+++ b/db/2011/advent_events.yml
@@ -118,3 +118,25 @@ trbmeetup:
   url: "http://www.tokyorubyistmeetup.org/"
   location: "Yoyogi Park"
   pub_date: '2011-06-13'
+
+cookpad_ja:
+  hosted_by_en: 'COOKPAD Inc.'
+  hosted_by_ja: 'COOKPAD Inc.'
+  name_en: 'Ruby Recipes and Japanese Cooking at COOKPAD (in Japanese)'
+  name_ja: 'Ruby Recipes and Japanese Cooking at COOKPAD (日本語)'
+  dtstart: '2011-07-14 19:00'
+  dtend: '2011-07-14 22:00'
+  url: "http://techlife.cookpad.com/2011/06/15/rrjcc/"
+  location: "Minato-ku, Shirokanedai"
+  pub_date: '2011-06-15'
+
+cookpad_en:
+  hosted_by_en: 'COOKPAD Inc.'
+  hosted_by_ja: 'COOKPAD Inc.'
+  name_en: 'Ruby Recipes and Japanese Cooking at COOKPAD (in English)'
+  name_ja: 'Ruby Recipes and Japanese Cooking at COOKPAD (英語)'
+  dtstart: '2011-07-15 19:00'
+  dtend: '2011-07-15 22:00'
+  url: "http://techlife.cookpad.com/2011/06/15/rrjcc/"
+  location: "Minato-ku, Shirokanedai"
+  pub_date: '2011-06-15'


### PR DESCRIPTION
RubyKaigi2011実行委員の皆様

クックパッド株式会社の井原と申します。

RubyKaigi Advent Calendar 2011への参加申し込みをさせていただきたいと思います。

http://techlife.cookpad.com/2011/06/15/rrjcc/

2つありまして、7/14（木）は日本語での開催、7/15（金）は英語での開催です。
内容は両日で若干異なる予定です。

日本の方にも海外の方にも楽しんでいただけるイベントにしたいと思いますので、よろしくお願いいたします。
