### PR TITLE
Hamamatsu.rbはRubyKaigi Advent Calendar 2011 の主旨に賛同します。

### DIFF
--- a/db/2011/advent_events.yml
+++ b/db/2011/advent_events.yml
@@ -118,6 +118,17 @@ trbmeetup:
   url: "http://www.tokyorubyistmeetup.org/"
   location: "Yoyogi Park"
   pub_date: '2011-06-13'
+  
+hamamatsu_rb:
+  hosted_by_en: 'Hamamatsu.rb'
+  hosted_by_ja: 'Hamamatsu.rb'
+  name_en: 'Hamamatsu.rb#5'
+  name_ja: 'Hamamatsu.rb#5'
+  dtstart: '2011-07-13 19:00'
+  dtend: '2011-07-13 21:00'
+  url: "http://atnd.org/events/16961"
+  location: "Hi-Cube (Hamamatsu, Japan)"
+  pub_date: '2011-06-17'
 
 cookpad_ja:
   hosted_by_en: 'COOKPAD Inc.'


### PR DESCRIPTION
Hamamatsu.rbは、今年3月に発足した静岡県浜松市周辺のRubyistが集まる地域コミュニティです。毎月第2水曜日に開催しています。メンバーは社会人と学生あわせて20人ぐらいです。

RubyKaigi2011には学生を含めて5人以上は参加する予定です。よろしくお願いします！
