### PR TITLE
Advent CalendarにRuby東海の勉強会を追加して下さい

### DIFF
--- a/db/2011/advent_events.yml
+++ b/db/2011/advent_events.yml
@@ -272,3 +272,14 @@ kintsuba_sweets:
   url: 'https://gist.github.com/1043321'
   location: 'Seika-cho, Kyoto, JAPAN'
   pub_date: '2011-06-27'
+
+ruby_tokai:
+  hosted_by_en: 'Ruby Tokai (@rubytokai)'
+  hosted_by_ja: 'Ruby東海 (@rubytokai)'
+  name_en: 'Ruby Tokai Meetup'
+  name_ja: 'Ruby東海第22回勉強会'
+  dtstart: '2011-07-08 19:00'
+  dtend: '2011-07-08 21:00'
+  url: 'http://wiki.ruby-tokai.org/?%C2%E822%B2%F3%CA%D9%B6%AF%B2%F1'
+  location: '株式会社ニューキャスト 名古屋本社 [<a href="http://maps.google.com/maps/ms?msid=212189921490393774253.00046a8dab003297e65de&msa=0&ll=35.169752,136.927848&spn=0.002863,0.004506">Google Map</a>]'
+  pub_date: '2011-06-28'


### PR DESCRIPTION
ささやかながら、名古屋周辺でもRuby会議の開催へ向けて、盛り上げていきたいと思います。7月8日（金）に開催されるRuby東海の第22回勉強会をAdvent Calendarに追加して下さい。よろしくお願いします。
