### PR TITLE
「Ruby Recipes and Japanese Cooking at COOKPAD (英語)」削除依頼

### DIFF
--- a/db/2011/advent_events.yml
+++ b/db/2011/advent_events.yml
@@ -163,17 +163,6 @@ cookpad_ja:
   location: "Minato-ku, Shirokanedai"
   pub_date: '2011-06-15'
 
-cookpad_en:
-  hosted_by_en: 'COOKPAD Inc.'
-  hosted_by_ja: 'COOKPAD Inc.'
-  name_en: 'Ruby Recipes and Japanese Cooking at COOKPAD (in English)'
-  name_ja: 'Ruby Recipes and Japanese Cooking at COOKPAD (英語)'
-  dtstart: '2011-07-15 19:00'
-  dtend: '2011-07-15 22:00'
-  url: "http://techlife.cookpad.com/2011/06/15/rrjcc/"
-  location: "Minato-ku, Shirokanedai"
-  pub_date: '2011-06-15'
-
 railstokyo:
   hosted_by_en: 'Rails Meeting Tokyo'
   hosted_by_ja: 'Rails Meeting Tokyo'


### PR DESCRIPTION
クックパッドの井原です。

7/14（木）および7/15（金）の両日、弊社オフィスにて「Ruby Recipes and Japanese Cooking at COOKPAD」を予定していたのですが、7/15の英語による開催を中止し、7/14の日本語による開催に一本化したいと思います。

7/15に参加希望をいただいていた方々には個別に連絡済みなのですが、Advent Calendarからの削除をお願いいたします。
